### PR TITLE
Profiles Demo: refactor data validation and adjust USDC amount

### DIFF
--- a/smart-wallet/profiles-demo/src/app/page.tsx
+++ b/smart-wallet/profiles-demo/src/app/page.tsx
@@ -43,7 +43,7 @@ export default function Home() {
 
       // Extract address if provided
       if (callbackData.physicalAddress) {
-        const addr = callbackData.physicalAddress.physicalAddress;
+        const addr = callbackData.physicalAddress;
         newResult.address = [
           addr.address1,
           addr.address2,


### PR DESCRIPTION
- Fix the "page.tsx" typing error in the callbackData.physicalAddress.physicalAddress (changed to callbackData.physicalAddress)

- In the data validation API, fix the undefined error while setting shipping address error messages.

- Adjust the transfer amount by updating the request calls in the API data validation (for example, from 0.01 USDC to 0.02 USDC).