### PR TITLE
feat: Use `platformReferrer` to distinguish TBA vs Zora coins

### DIFF
--- a/base-app-coins/utils.ts
+++ b/base-app-coins/utils.ts
@@ -1,8 +1,11 @@
 import { Ether, Token, type Currency } from "@uniswap/sdk-core";
 import { Pool, type PoolKey } from "@uniswap/v4-sdk";
-import { erc20Abi, getContract, zeroAddress } from "viem";
+import { erc20Abi, getContract, parseAbi, zeroAddress } from "viem";
 import { base } from "viem/chains";
 import { publicClient, stateView } from "./chain";
+import { ADDRESS_ZERO } from "@uniswap/v3-sdk";
+
+const BASE_PLATFORM_REFERRER = "0x55C88bB05602Da94fCe8FEadc1cbebF5B72c2453";
 
 export async function loadData(key: PoolKey) {
     const [currency0, currency1] = await Promise.all([
@@ -26,6 +29,36 @@ export async function loadData(key: PoolKey) {
         tick,
     )
     return pool;
+}
+
+export async function categorizeAppType(pool: Pool) {
+    async function tryGetPlatformReferrer(address: string) {
+        const zoraBaseCoin = getContract({
+            abi: parseAbi([
+                "function platformReferrer() view returns (address)",
+            ]),
+            address: address as `0x${string}`,
+            client: publicClient
+        })
+
+        try {
+            const platformReferrer = await zoraBaseCoin.read.platformReferrer()
+            return platformReferrer
+        } catch (error) {
+            return ADDRESS_ZERO
+        }
+    }
+
+    const [currency0PlatformReferrer, currency1PlatformReferrer] = await Promise.all([
+        tryGetPlatformReferrer(pool.currency0.wrapped.address),
+        tryGetPlatformReferrer(pool.currency1.wrapped.address)
+    ])
+
+    if ([currency0PlatformReferrer, currency1PlatformReferrer].includes(BASE_PLATFORM_REFERRER)) {
+        return "TBA"
+    }
+
+    return "ZORA"
 }
 
 export async function getCurrency(address: string): Promise<Currency> {


### PR DESCRIPTION
Previously we were distinguishing TBA vs Zora app coins based on paired currencies. This wasn't very reliable or sustainable as the pairings may change over time.

This PR updates the demo code to look at the platform referrer address instead, as Base App uses a specific referrer address for all coins created via it using Zora