### PR TITLE
Update Smart Wallet Demo section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ This repository contains example applications demonstrating various [Base] and [
 
 ## Available Demos
 
-### Smart Wallet Demo
+### Base Account Demo
 
-- Location: `smart-wallet/`
+- Location: `base-account/`
 - Description: Demonstrates the implementation of smart contract wallets on Base
 - Features: Spend Limits, Sub-accounts, and Zora SDK examples
 


### PR DESCRIPTION
## Context
This PR updates the README to:
- Change the "Smart Wallet Demo" title to "Base Account Demo".
- Update the `smart-wallet/` link to point to the new `base-account/` route.