### PR TITLE
fix: add valtio override to resolve React 19 peer dependency warning

### DIFF
--- a/mini-apps/templates/minikit/new-mini-app-quickstart/package.json
+++ b/mini-apps/templates/minikit/new-mini-app-quickstart/package.json
@@ -29,5 +29,8 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "valtio": "^2.0.0"
   }
 }


### PR DESCRIPTION
valtio has a peer dependency conflict with React 19. Added an overrides entry to resolve it so npm install does not throw warnings on fresh installs.