### PR TITLE
docs(readme): update minimum Node.js version from v16 to v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This repository contains example applications demonstrating various [Base] and [
 
 ## Requirements
 
-- Node.js (v16 or higher)
+- Node.js (v18 or higher)
 - npm or yarn
 - A Base-compatible wallet (like Coinbase Wallet)
 


### PR DESCRIPTION
Fixes #119

## Summary

The root README listed Node.js v16 as the minimum requirement, but v16 reached end-of-life in September 2023. Updated to v18 which is the current minimum LTS version.