### PR TITLE
docs(readme): update minimum Node.js version requirement from v16 to v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This repository contains example applications demonstrating various [Base] and [
 
 ## Requirements
 
-- Node.js (v16 or higher)
+- Node.js (v18 or higher)
 - npm or yarn
 - A Base-compatible wallet (like Coinbase Wallet)
 


### PR DESCRIPTION
README says Node.js v16 is the minimum but the project actually requires v18. Node 16 hit end of life in September 2023 so anyone following the README and installing v16 will run into issues.