### PR TITLE
docs(readme): update minimum Node.js version from v16 to v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This repository contains example applications demonstrating various [Base] and [
 
 ## Requirements
 
-- Node.js (v16 or higher)
+- Node.js (v18 or higher)
 - npm or yarn
 - A Base-compatible wallet (like Coinbase Wallet)
 


### PR DESCRIPTION
Closes #119

## Summary
Node.js v16 reached end-of-life in September 2023 and is no longer maintained. The current LTS versions are v18 and v20.

## Changes
- Updated the README.md requirement from `Node.js (v16 or higher)` to `Node.js (v18 or higher)` to reflect supported versions.