### PR TITLE
docs(base-account): fix broken README links in demo templates

### DIFF
--- a/base-account/base-account-privy-template/README.md
+++ b/base-account/base-account-privy-template/README.md
@@ -228,4 +228,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## 📄 License
 
-This project is open source and available under the [MIT License](LICENSE).
+This project is open source and available under the [MIT License](../../LICENSE).

--- a/base-account/base-account-rainbow-template/README.md
+++ b/base-account/base-account-rainbow-template/README.md
@@ -43,7 +43,7 @@ Open [http://localhost:3000](http://localhost:3000) to see your app.
 
 ## Documentation
 
-For a complete integration guide including both `ConnectButton` and `WalletButton` implementations, check out the [Base Account RainbowKit Setup Guide](https://github.com/base/demos/tree/master/base-account/base-account-rainbow-template/GUIDE.md).
+For a complete integration guide including both `ConnectButton` and `WalletButton` implementations, check out the [Base Account RainbowKit Setup Guide](GUIDE.mdx).
 
 ## Learn More
 


### PR DESCRIPTION
Closes #124

## Changes
- **Privy template**: Fixed broken `LICENSE` link — changed from `LICENSE` (local, doesn't exist) to `../../LICENSE` (repo root)
- **Rainbow template**: Fixed broken guide link — changed from `GUIDE.md` to `GUIDE.mdx` (file was renamed to .mdx)