### PR TITLE
docs: fix broken readme links in base-account templates

### DIFF
--- a/base-account/base-account-privy-template/README.md
+++ b/base-account/base-account-privy-template/README.md
@@ -228,4 +228,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## 📄 License
 
-This project is open source and available under the [MIT License](LICENSE).
+This project is open source and available under the [MIT License](../../LICENSE).

--- a/base-account/base-account-rainbow-template/README.md
+++ b/base-account/base-account-rainbow-template/README.md
@@ -43,7 +43,7 @@ Open [http://localhost:3000](http://localhost:3000) to see your app.
 
 ## Documentation
 
-For a complete integration guide including both `ConnectButton` and `WalletButton` implementations, check out the [Base Account RainbowKit Setup Guide](https://github.com/base/demos/tree/master/base-account/base-account-rainbow-template/GUIDE.md).
+For a complete integration guide including both `ConnectButton` and `WalletButton` implementations, check out the [Base Account RainbowKit Setup Guide](./GUIDE.mdx).
 
 ## Learn More
 


### PR DESCRIPTION
Two README links return 404.

Privy template: the license link points to LICENSE inside the template folder but that file only exists at the repo root. Changed it to ../../LICENSE.

Rainbow template: the link goes to GUIDE.md which does not exist. The actual file is GUIDE.mdx so I pointed it at ./GUIDE.mdx.

Checked both targets resolve. Docs only no code change.

Closes #124
