### PR TITLE
fix(demos): pin @coinbase/onchainkit to the locked 0.38.x instead of "latest"

### DIFF
--- a/mini-apps/workshops/mini-neynar/package.json
+++ b/mini-apps/workshops/mini-neynar/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "latest",
+    "@coinbase/onchainkit": "^0.38.10",
     "@neynar/nodejs-sdk": "^2.25.1",
     "@farcaster/frame-sdk": "^0.0.35",
     "@upstash/redis": "^1.34.4",

--- a/mini-apps/workshops/my-mini-zora/package.json
+++ b/mini-apps/workshops/my-mini-zora/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "latest",
+    "@coinbase/onchainkit": "^0.38.8",
     "@farcaster/frame-sdk": "^0.0.36",
     "@radix-ui/react-slot": "^1.2.0",
     "@tanstack/react-query": "^5",

--- a/mini-apps/workshops/my-simple-mini-app/package.json
+++ b/mini-apps/workshops/my-simple-mini-app/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "latest",
+    "@coinbase/onchainkit": "^0.38.10",
     "@farcaster/frame-sdk": "^0.0.35",
     "@upstash/redis": "^1.34.4",
     "next": "^14.2.15",

--- a/mini-apps/workshops/three-card-monte/package.json
+++ b/mini-apps/workshops/three-card-monte/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@coinbase/cdp-sdk": "^1.9.0",
-    "@coinbase/onchainkit": "latest",
+    "@coinbase/onchainkit": "^0.38.13",
     "@farcaster/frame-sdk": "^0.0.35",
     "@radix-ui/react-slot": "^1.2.2",
     "@tanstack/react-query": "^5",


### PR DESCRIPTION
## Summary

Four workshop demos declare `"@coinbase/onchainkit": "latest"` while their committed `package-lock.json` is locked to a 0.38.x build. `latest` on npm is currently **1.1.2**, a major version ahead, so a fresh `npm install` in any of them resolves the floating tag and pulls OnchainKit 1.x into a demo written and locked against the 0.38 API.

Each manifest is pinned to a caret range matching the version already resolved in its own lockfile, so the two agree and installs stay reproducible.

## Affected demos

| Demo | before | after | lockfile |
| --- | --- | --- | --- |
| `mini-apps/workshops/mini-neynar` | `latest` | `^0.38.10` | 0.38.10 |
| `mini-apps/workshops/my-mini-zora` | `latest` | `^0.38.8` | 0.38.8 |
| `mini-apps/workshops/my-simple-mini-app` | `latest` | `^0.38.10` | 0.38.10 |
| `mini-apps/workshops/three-card-monte` | `latest` | `^0.38.13` | 0.38.13 |

No lockfile changes: every pin is the version already present there.

## Rebased

This PR originally also touched `paymaster/hangman-onchain` and `paymaster/onchain-game-lingos`. Both demos were removed from the repo in #137, so the branch has been rebuilt on current `master` and now covers only the four demos that still carry the floating tag.

## Not included

Upgrading these demos to OnchainKit 1.x is separate work with real API changes behind it. This only stops the unintended major-version jump.
