### PR TITLE
Resolve Unauthenticated Minting, Predictable Randomness, and Missing Rate Limits in `three-card-monte`

### DIFF
--- a/mini-apps/workshops/three-card-monte/app/api/game/start/route.ts
+++ b/mini-apps/workshops/three-card-monte/app/api/game/start/route.ts
@@ -1,0 +1,62 @@
+// app/api/game/start/route.ts
+import { NextResponse } from "next/server";
+import { isAddress } from "viem";
+
+import { createRound } from "@/lib/game-rounds";
+import { clientKey, withinRateLimit } from "@/lib/rate-limit";
+
+/**
+ * Opens a server-authoritative round and returns its identifier.
+ *
+ * The winning card is chosen here, stored server-side, and deliberately left out
+ * of the response. The browser animation in `components/three-card-monte-game.tsx`
+ * is presentation only; `/api/win` decides the outcome by comparing the player's
+ * submitted pick against the card recorded here.
+ */
+
+const RATE_LIMIT_MAX_REQUESTS = 20;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+export async function POST(request: Request) {
+  if (
+    !withinRateLimit(
+      clientKey(request),
+      RATE_LIMIT_MAX_REQUESTS,
+      RATE_LIMIT_WINDOW_MS,
+    )
+  ) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (typeof body !== "object" || body === null) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { playerAddress } = body as Record<string, unknown>;
+  if (typeof playerAddress !== "string" || !isAddress(playerAddress)) {
+    return NextResponse.json(
+      { error: "playerAddress must be a valid EVM address" },
+      { status: 400 },
+    );
+  }
+
+  const gameId = await createRound(playerAddress);
+  if (!gameId) {
+    // Redis is unconfigured, so no round can be recorded and nothing could be
+    // verified at claim time. Failing here is the point: the alternative is
+    // paying out on the client's word, which is the flaw this replaced.
+    console.error("Cannot open a round: REDIS_URL / REDIS_TOKEN are not set");
+    return NextResponse.json(
+      { error: "Game rounds are unavailable" },
+      { status: 503 },
+    );
+  }
+
+  return NextResponse.json({ gameId });
+}

--- a/mini-apps/workshops/three-card-monte/app/api/win/route.ts
+++ b/mini-apps/workshops/three-card-monte/app/api/win/route.ts
@@ -1,10 +1,38 @@
+// app/api/win/route.ts
 import { NextResponse } from "next/server";
-import { createPublicClient, http, encodeFunctionData } from "viem";
+import { createPublicClient, http, encodeFunctionData, isAddress } from "viem";
 import { baseSepolia } from "viem/chains";
 import { GAME_CONTRACT_ADDRESS_SEPOLIA } from "@/lib/constants";
 import { GAME_CONTRACT_ABI } from "@/lib/abi";
 import { getCDPAccountByAddress } from "@/lib/cdp/account";
 import { cdp } from "@/lib/cdp/client";
+import { CARD_IDS, GAME_ID_PATTERN, claimRound } from "@/lib/game-rounds";
+import { clientKey, withinRateLimit } from "@/lib/rate-limit";
+
+/**
+ * Records an onchain reward for a player who won a verified round.
+ *
+ * `recordReward(player, true)` is the authorisation that later lets that address
+ * call `claimReward` and take funds out of the game contract, and it is sent by
+ * the deployment's own CDP signer. The previous implementation performed no
+ * verification at all: it read `playerAddress`, `score` and `gameId` from the
+ * request body, checked only that all three were truthy, then discarded `score`
+ * and `gameId` and paid out. Consequences:
+ *
+ *   - No authentication, so any anonymous caller could mark any address a winner.
+ *   - No round validation, so a caller could repeat the request indefinitely.
+ *   - `!score` rejected a legitimate score of 0 while accepting the string "win".
+ *   - The signer address was hardcoded, with `process.env.CDP_SIGNER_ADDRESS`
+ *     commented out beside it.
+ *   - The catch block returned `error.message` to the caller, exposing CDP and
+ *     RPC internals.
+ *
+ * Every payout now consumes a round that this server opened, bound to the same
+ * address, whose winning card the client was never told. See `lib/game-rounds.ts`.
+ */
+
+const RATE_LIMIT_MAX_REQUESTS = 10;
+const RATE_LIMIT_WINDOW_MS = 60_000;
 
 // Initialize the public client for transaction monitoring
 const publicClient = createPublicClient({
@@ -13,34 +41,105 @@ const publicClient = createPublicClient({
 });
 
 export async function POST(request: Request) {
+  if (
+    !withinRateLimit(
+      clientKey(request),
+      RATE_LIMIT_MAX_REQUESTS,
+      RATE_LIMIT_WINDOW_MS,
+    )
+  ) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  let body: unknown;
   try {
-    // Parse the request body
-    const body = await request.json();
-    const { playerAddress, score, gameId } = body;
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (typeof body !== "object" || body === null) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-    if (!playerAddress || !score || !gameId) {
-      return NextResponse.json(
-        { error: "Missing required parameters" },
-        { status: 400 },
-      );
-    }
+  const { playerAddress, gameId, selectedCardId } = body as Record<
+    string,
+    unknown
+  >;
 
-    // Get the CDP account that will send the transaction
-    const account = await getCDPAccountByAddress(
-      "0x72CEf69033b684D46c684FA7292530e4b06Ad9BF", //process.env.CDP_SIGNER_ADDRESS!,
+  if (typeof playerAddress !== "string" || !isAddress(playerAddress)) {
+    return NextResponse.json(
+      { error: "playerAddress must be a valid EVM address" },
+      { status: 400 },
     );
+  }
+  if (typeof gameId !== "string" || !GAME_ID_PATTERN.test(gameId)) {
+    return NextResponse.json(
+      { error: "gameId must be an identifier issued by /api/game/start" },
+      { status: 400 },
+    );
+  }
+  // An explicit type check rather than a truthiness test: card id 0 would be
+  // rejected by `!selectedCardId` even if it were valid, which is the bug the
+  // original `!score` check had.
+  if (
+    typeof selectedCardId !== "number" ||
+    !CARD_IDS.includes(selectedCardId as (typeof CARD_IDS)[number])
+  ) {
+    return NextResponse.json(
+      { error: `selectedCardId must be one of ${CARD_IDS.join(", ")}` },
+      { status: 400 },
+    );
+  }
 
-    // Prepare the transaction
+  const signerAddress = process.env.CDP_SIGNER_ADDRESS;
+  if (!signerAddress || !isAddress(signerAddress)) {
+    console.error("CDP_SIGNER_ADDRESS is not set to a valid address");
+    return NextResponse.json(
+      { error: "Rewards are not configured" },
+      { status: 503 },
+    );
+  }
+
+  const claim = await claimRound(gameId, playerAddress, selectedCardId);
+
+  switch (claim.outcome) {
+    case "unavailable":
+      console.error("Cannot verify a round: REDIS_URL / REDIS_TOKEN are not set");
+      return NextResponse.json(
+        { error: "Game rounds are unavailable" },
+        { status: 503 },
+      );
+    case "unknown-round":
+      // Also covers rounds that have expired. Deliberately indistinguishable
+      // from a fabricated identifier.
+      return NextResponse.json(
+        { error: "Unknown or expired round" },
+        { status: 404 },
+      );
+    case "wrong-player":
+      return NextResponse.json(
+        { error: "This round belongs to a different address" },
+        { status: 403 },
+      );
+    case "already-played":
+      return NextResponse.json(
+        { error: "This round has already been played" },
+        { status: 409 },
+      );
+    case "lost":
+      // A losing guess still consumes the round, so it cannot be retried.
+      return NextResponse.json({ success: true, won: false });
+    case "won":
+      break;
+  }
+
+  try {
+    const account = await getCDPAccountByAddress(signerAddress);
+
     const txData = encodeFunctionData({
       abi: GAME_CONTRACT_ABI,
       functionName: "recordReward",
       args: [playerAddress as `0x${string}`, true],
-    });
-
-    console.log("Sending transaction with data:", {
-      to: GAME_CONTRACT_ADDRESS_SEPOLIA,
-      data: txData,
-      from: account.address,
     });
 
     const txResult = await cdp.evm.sendTransaction({
@@ -52,34 +151,36 @@ export async function POST(request: Request) {
       },
     });
 
-    console.log("Transaction sent:", {
-      hash: txResult.transactionHash,
-      network: "base-sepolia",
-    });
-
-    // Wait for transaction confirmation
     const receipt = await publicClient.waitForTransactionReceipt({
       hash: txResult.transactionHash,
     });
 
-    console.log("Transaction receipt:", {
+    console.log("Recorded reward:", {
+      gameId,
       hash: receipt.transactionHash,
       blockNumber: receipt.blockNumber.toString(),
-      gasUsed: receipt.gasUsed.toString(),
+      status: receipt.status,
     });
+
+    if (receipt.status !== "success") {
+      return NextResponse.json(
+        { error: "Reward transaction reverted" },
+        { status: 502 },
+      );
+    }
 
     return NextResponse.json({
       success: true,
+      won: true,
       transactionHash: txResult.transactionHash,
     });
   } catch (error) {
+    // Logged server-side only. CDP and RPC errors carry account identifiers and
+    // request metadata that callers have no need to see.
     console.error("Error processing game win:", error);
     return NextResponse.json(
-      {
-        error: "Failed to process game win",
-        details: error instanceof Error ? error.message : "Unknown error",
-      },
-      { status: 500 },
+      { error: "Failed to process game win" },
+      { status: 502 },
     );
   }
 }

--- a/mini-apps/workshops/three-card-monte/lib/game-rounds.ts
+++ b/mini-apps/workshops/three-card-monte/lib/game-rounds.ts
@@ -1,0 +1,163 @@
+// lib/game-rounds.ts
+import { randomBytes, randomInt } from "node:crypto";
+
+import { redis } from "@/lib/redis";
+
+/**
+ * Server-authoritative rounds for the three-card monte reward flow.
+ *
+ * Why this exists: `recordReward(player, true)` is the onchain authorisation that
+ * lets a player call `claimReward`. The route that sends it used to accept
+ * `playerAddress`, `score` and `gameId` from the request body and pay out without
+ * checking any of them — `score` and `gameId` were tested for presence and then
+ * never read. Any anonymous caller could mark any address as a winner, as often
+ * as they liked, and drain the reward pool.
+ *
+ * The client cannot be the source of truth about whether it won, because the
+ * whole game runs in the browser: `isTarget` lives in React state and the
+ * win/lose decision in `handleCardClick` is client-side. So the server picks the
+ * winning card itself, keeps it out of the response, and pays out only when the
+ * submitted pick matches a round that has not already been used.
+ */
+
+const ROUND_KEY_PREFIX = "tcm:round:";
+
+/** A round must be played within this window. */
+export const ROUND_TTL_SECONDS = 5 * 60;
+
+/** Card identifiers rendered by the game component. */
+export const CARD_IDS = [1, 2, 3] as const;
+
+export type Round = {
+  /** Lowercased address permitted to claim this round. */
+  player: string;
+  /** The card the player must select. Never sent to the client. */
+  winningCardId: number;
+  /** Issued-at, in milliseconds since the epoch. */
+  createdAt: number;
+};
+
+export type ClaimResult =
+  | { outcome: "won"; player: string }
+  | { outcome: "lost" }
+  | { outcome: "unknown-round" }
+  | { outcome: "already-played" }
+  | { outcome: "wrong-player" }
+  | { outcome: "unavailable" };
+
+function roundKey(gameId: string): string {
+  return `${ROUND_KEY_PREFIX}${gameId}`;
+}
+
+function claimKey(gameId: string): string {
+  return `${ROUND_KEY_PREFIX}${gameId}:claimed`;
+}
+
+/** `gameId` values this module issues: 32 hex characters, nothing else. */
+export const GAME_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+/**
+ * Normalises a value read back from Redis into a {@link Round}.
+ *
+ * `@upstash/redis` may hand back either the raw string or an already-parsed
+ * object depending on how the value was written, so both are handled and
+ * anything unrecognised is rejected rather than coerced.
+ */
+function toRound(value: unknown): Round | null {
+  let candidate: unknown = value;
+  if (typeof candidate === "string") {
+    try {
+      candidate = JSON.parse(candidate);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof candidate !== "object" || candidate === null) {
+    return null;
+  }
+  const { player, winningCardId, createdAt } = candidate as Partial<Round>;
+  if (
+    typeof player !== "string" ||
+    typeof winningCardId !== "number" ||
+    typeof createdAt !== "number" ||
+    !CARD_IDS.includes(winningCardId as (typeof CARD_IDS)[number])
+  ) {
+    return null;
+  }
+  return { player, winningCardId, createdAt };
+}
+
+/**
+ * Opens a round for `player` and returns its identifier.
+ *
+ * Returns `null` when Redis is not configured. Callers must treat that as a
+ * hard failure: with nowhere to record the winning card there is nothing to
+ * verify against later, and paying out anyway would restore the original hole.
+ */
+export async function createRound(player: string): Promise<string | null> {
+  if (!redis) {
+    return null;
+  }
+
+  // 128 bits from a CSPRNG. An unguessable identifier is what stops a caller
+  // from claiming a round it never opened.
+  const gameId = randomBytes(16).toString("hex");
+
+  const round: Round = {
+    player: player.toLowerCase(),
+    // `randomInt` is rejection-sampled and free of the modulo bias that
+    // `Math.floor(Math.random() * n)` carries, and it is not predictable from
+    // previously observed outputs.
+    winningCardId: CARD_IDS[randomInt(CARD_IDS.length)],
+    createdAt: Date.now(),
+  };
+
+  await redis.set(roundKey(gameId), JSON.stringify(round), {
+    ex: ROUND_TTL_SECONDS,
+  });
+
+  return gameId;
+}
+
+/**
+ * Consumes a round and reports the outcome.
+ *
+ * The round is consumed whether or not the guess was correct, so each round
+ * yields exactly one attempt.
+ */
+export async function claimRound(
+  gameId: string,
+  player: string,
+  selectedCardId: number,
+): Promise<ClaimResult> {
+  if (!redis) {
+    return { outcome: "unavailable" };
+  }
+
+  const round = toRound(await redis.get(roundKey(gameId)));
+  if (!round) {
+    return { outcome: "unknown-round" };
+  }
+
+  if (round.player !== player.toLowerCase()) {
+    return { outcome: "wrong-player" };
+  }
+
+  // Atomic single-use gate. `nx` means the write only succeeds if the key does
+  // not exist, so exactly one concurrent request can proceed past this point —
+  // this is what prevents a replay race from collecting several payouts from one
+  // round.
+  const reserved = await redis.set(claimKey(gameId), "1", {
+    nx: true,
+    ex: ROUND_TTL_SECONDS,
+  });
+  if (reserved === null) {
+    return { outcome: "already-played" };
+  }
+
+  if (selectedCardId !== round.winningCardId) {
+    return { outcome: "lost" };
+  }
+
+  return { outcome: "won", player: round.player };
+}

--- a/mini-apps/workshops/three-card-monte/lib/rate-limit.ts
+++ b/mini-apps/workshops/three-card-monte/lib/rate-limit.ts
@@ -1,0 +1,87 @@
+// lib/rate-limit.ts
+
+/**
+ * Best-effort, in-process sliding-window rate limiter.
+ *
+ * The reward routes spend real funds from the deployment's CDP signer, so the
+ * request rate has to be bounded even after a caller is otherwise authorised.
+ *
+ * Limitation, stated plainly: the counters live in process memory, so each
+ * serverless instance enforces its own budget and a horizontally scaled
+ * deployment multiplies the effective limit by the instance count. Redis is
+ * already a dependency of this project and would be the right home for a real
+ * guarantee; this is a floor, not a ceiling.
+ */
+
+/** Distinct client keys tracked before the table is pruned. */
+const MAX_TRACKED_KEYS = 5_000;
+
+const buckets = new Map<string, number[]>();
+
+/**
+ * Derives a client key from proxy headers.
+ *
+ * These headers are attacker-controlled unless a trusted proxy overwrites them.
+ * Vercel and most managed platforms do overwrite `x-forwarded-for`; behind
+ * anything that does not, the limiter degrades to one shared bucket rather than
+ * failing open per-request.
+ */
+export function clientKey(request: Request): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    // The left-most entry is the original client as recorded by the first proxy.
+    const first = forwardedFor.split(",")[0]?.trim();
+    if (first) {
+      return first;
+    }
+  }
+  return request.headers.get("x-real-ip")?.trim() || "unknown";
+}
+
+/**
+ * Records a request against `key` and reports whether it is within budget.
+ *
+ * @param key Client identifier, typically from {@link clientKey}.
+ * @param maxRequests Requests permitted per window.
+ * @param windowMs Window length in milliseconds.
+ */
+export function withinRateLimit(
+  key: string,
+  maxRequests: number,
+  windowMs: number,
+): boolean {
+  const now = Date.now();
+  const cutoff = now - windowMs;
+
+  if (buckets.size > MAX_TRACKED_KEYS) {
+    // Unbounded growth is itself a denial-of-service vector, so keys whose
+    // entire history has aged out are dropped before a new one is admitted.
+    //
+    // `forEach` rather than `for...of`: this project's `tsconfig.json` sets no
+    // `target`, so it compiles as ES5 and iterating a `Map` directly would
+    // require `--downlevelIteration`. Deletions are deferred into `stale` so the
+    // map is not mutated while it is being walked.
+    const stale: string[] = [];
+    buckets.forEach((timestamps: number[], candidate: string) => {
+      const live = timestamps.filter((timestamp: number) => timestamp > cutoff);
+      if (live.length === 0) {
+        stale.push(candidate);
+      } else {
+        buckets.set(candidate, live);
+      }
+    });
+    stale.forEach((candidate) => buckets.delete(candidate));
+  }
+
+  const recent = (buckets.get(key) ?? []).filter(
+    (timestamp) => timestamp > cutoff,
+  );
+  if (recent.length >= maxRequests) {
+    buckets.set(key, recent);
+    return false;
+  }
+
+  recent.push(now);
+  buckets.set(key, recent);
+  return true;
+}

--- a/mini-apps/workshops/three-card-monte/lib/shuffle.ts
+++ b/mini-apps/workshops/three-card-monte/lib/shuffle.ts
@@ -1,8 +1,39 @@
-// Fisher-Yates shuffle algorithm
+// lib/shuffle.ts
+
+// Fisher-Yates shuffle backed by a cryptographically secure random source.
+//
+// `Math.random()` was used here previously. V8 implements it with xorshift128+,
+// whose internal state can be recovered from a modest number of observed
+// outputs, after which every subsequent value is predictable. The card order is
+// presentation only now that `/api/game/start` chooses the winning card
+// server-side, but a shuffle helper that leaks its future outputs is the kind of
+// thing that gets reused somewhere it matters.
+//
+// `Math.floor(Math.random() * n)` also carries modulo bias; `randomBelow` below
+// uses rejection sampling instead, so every index is equally likely.
+
+/** Returns a uniformly distributed integer in `[0, bound)`. `bound` must be >= 1. */
+function randomBelow(bound: number): number {
+  // Largest multiple of `bound` that fits in a uint32. Values at or above this
+  // limit are discarded rather than folded back into range, which is what keeps
+  // the distribution uniform.
+  const limit = Math.floor(0x1_0000_0000 / bound) * bound
+  const buffer = new Uint32Array(1)
+
+  // Available in browsers and in Node 19+, so this works in client components
+  // and in route handlers alike.
+  for (;;) {
+    globalThis.crypto.getRandomValues(buffer)
+    if (buffer[0] < limit) {
+      return buffer[0] % bound
+    }
+  }
+}
+
 export function shuffle<T>(array: T[]): T[] {
   const newArray = [...array]
   for (let i = newArray.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
+    const j = randomBelow(i + 1)
     ;[newArray[i], newArray[j]] = [newArray[j], newArray[i]]
   }
   return newArray


### PR DESCRIPTION
### Description
This pull request addresses findings F-03, F-11, F-12, and F-13 from the workspace security audit[cite: 30]. It completely overhauls the game logic to make rounds server-authoritative, prevents unauthorized on-chain reward minting, introduces proper rate-limiting for gas-spending endpoints, and hardens the random number generation logic against state recovery attacks.

### Key Changes & Remediations

#### 1. Server-Authoritative Reward Minting (F-03)
* **Closing the Minting Oracle:** The `/api/win` endpoint previously accepted unsigned, unverified win claims directly from the client request body and minted rewards unconditionally[cite: 30]. This has been refactored to rely on a server-side Redis validation flow.
* **Secure State Initialization:** A new route, `/api/game/start`, securely selects the winning card using `crypto.randomInt` and stores it in Redis under an unguessable 128-bit `gameId`[cite: 30]. The winning card is deliberately excluded from the client response[cite: 30].
* **Atomic Single-Use Gate:** The `claimRound` logic uses a `SET NX EX` atomic lock to prevent concurrent replay race conditions, ensuring a round can only ever be consumed once[cite: 30].

#### 2. Rate Limiting for Gas & Signer Endpoints (F-11)
* **Sliding-Window Implementation:** A new in-memory rate limiter (`lib/rate-limit.ts`) has been introduced to protect the application's budget[cite: 30]. The game start endpoint is capped at 20 requests/min, while the payout endpoint is restricted to 10 requests/min.
* **Safe Cache Pruning:** The rate-limit cache pruning defers deletions to avoid ES5 `TS2802` `Map` iteration mutation errors[cite: 30].

#### 3. Cryptographically Secure Randomness (F-12)
* **CSPRNG Implementation:** Replaced the vulnerable `Math.random()` (which relies on `xorshift128+` and is susceptible to state recovery and modulo bias) with `crypto.getRandomValues()` paired with explicit rejection sampling (`lib/shuffle.ts`)[cite: 30].

#### 4. Error Masking (F-13)
* **Information Leakage Prevented:** The `app/api/win/route.ts` previously returned raw `error.message` strings from CDP and RPC internals back to the caller[cite: 30]. All upstream errors are now logged strictly server-side and resolved to the client via generic `502 Bad Gateway` or `400 Bad Request` responses[cite: 30].