### PR TITLE
Resolve Unsigned Authentication Bypass and Forgeable Sessions in `agent-spend-permissions`

### DIFF
--- a/base-account/agent-spend-permissions/src/app/api/auth/verify/route.ts
+++ b/base-account/agent-spend-permissions/src/app/api/auth/verify/route.ts
@@ -1,74 +1,134 @@
+// src/app/api/auth/verify/route.ts
 import { NextRequest, NextResponse } from 'next/server'
-import { createPublicClient, http } from 'viem'
+import { createPublicClient, http, isAddress } from 'viem'
 import { base } from 'viem/chains'
+// SIWE helpers live behind the `viem/siwe` entrypoint, not the package root.
+import { parseSiweMessage } from 'viem/siwe'
 
-const client = createPublicClient({ chain: base, transport: http() })
-// Simple in-memory nonce store (swap for Redis or DB in production)
-const nonces = new Set<string>()
+import { SESSION_COOKIE_NAME, SESSION_TTL_SECONDS, createSessionToken } from '@/lib/session'
+import { consumeNonce, issueNonce } from '@/lib/siwe-nonce'
+
+/**
+ * Sign-In with Ethereum.
+ *
+ * Three defects were fixed here.
+ *
+ * 1. **Forgeable session token.** The issued token was
+ *    `base64(`${address}:${Date.now()}`)` — unsigned, so anyone could mint one for
+ *    any address and skip this route entirely. It is now HMAC-signed; see
+ *    `@/lib/session`.
+ *
+ * 2. **No domain binding.** The nonce was pulled out of the message with
+ *    `message.match(/Nonce: (\w+)/)` and nothing else in the message was checked.
+ *    A signature the user produced for any other site whose SIWE message happened
+ *    to carry a nonce from this deployment would verify here. The message is now
+ *    parsed as SIWE and its `domain`, `address`, `nonce` and validity window are
+ *    all required to match.
+ *
+ * 3. **Stateful, non-expiring nonces.** See `@/lib/siwe-nonce`.
+ */
+
+const client = createPublicClient({
+  chain: base,
+  transport: http(process.env.NEXT_PUBLIC_BASE_RPC_URL || 'https://mainnet.base.org'),
+})
+
+/**
+ * The domain the signed message must name.
+ *
+ * `SIWE_DOMAIN` should be set in any deployment that sits behind a proxy or CDN.
+ * Falling back to the `Host` header keeps local development working; that header
+ * is client-supplied, but requiring it to match the message still forces an
+ * attacker to have obtained a signature naming this exact domain.
+ */
+function expectedDomain(request: NextRequest): string | null {
+  return process.env.SIWE_DOMAIN || request.headers.get('host')
+}
 
 export async function POST(request: NextRequest) {
   try {
-    const { address, message, signature } = await request.json()
+    const body: unknown = await request.json()
+    if (typeof body !== 'object' || body === null) {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
 
-    if (!address || !message || !signature) {
-      return NextResponse.json({ 
-        error: 'Missing required fields: address, message, signature' 
+    const { address, message, signature } = body as Record<string, unknown>
+
+    if (typeof address !== 'string' || typeof message !== 'string' || typeof signature !== 'string') {
+      return NextResponse.json({
+        error: 'Missing required fields: address, message, signature'
       }, { status: 400 })
     }
-
-    console.log('Verifying signature for address:', address)
-
-    // Extract nonce from message (SIWE format)
-    const nonce = message.match(/Nonce: (\w+)/)?.[1]
-    if (!nonce) {
-      return NextResponse.json({ 
-        error: 'Invalid message format - nonce not found' 
-      }, { status: 400 })
+    if (!isAddress(address)) {
+      return NextResponse.json({ error: 'Invalid address' }, { status: 400 })
+    }
+    // An upper bound on work done before anything is verified.
+    if (message.length > 4096 || signature.length > 8192) {
+      return NextResponse.json({ error: 'Message or signature too large' }, { status: 400 })
     }
 
-    // Check if nonce is valid and not reused
-    if (!nonces.has(nonce)) {
-      return NextResponse.json({ 
-        error: 'Invalid or expired nonce' 
-      }, { status: 401 })
+    const domain = expectedDomain(request)
+    if (!domain) {
+      console.error('Cannot determine the expected SIWE domain; set SIWE_DOMAIN')
+      return NextResponse.json({ error: 'Authentication is not configured' }, { status: 503 })
     }
 
-    // Remove nonce to prevent reuse
-    nonces.delete(nonce)
+    // Parse the message as SIWE rather than pattern-matching one line out of it.
+    const siwe = parseSiweMessage(message)
+    if (!siwe.nonce || !siwe.address) {
+      return NextResponse.json({ error: 'Invalid message format' }, { status: 400 })
+    }
 
-    // Verify the signature
-    const isValid = await client.verifyMessage({ 
-      address: address as `0x${string}`, 
-      message, 
-      signature: signature as `0x${string}` 
+    const nonceCheck = consumeNonce(siwe.nonce)
+    if (nonceCheck === 'unavailable') {
+      console.error('SESSION_SECRET is not set; sign-in cannot be completed')
+      return NextResponse.json({ error: 'Authentication is not configured' }, { status: 503 })
+    }
+    if (nonceCheck !== 'ok') {
+      // Malformed, expired and reused are answered identically so the response
+      // does not help an attacker distinguish them.
+      return NextResponse.json({ error: 'Invalid or expired nonce' }, { status: 401 })
+    }
+
+    // The address in the body and the address inside the signed message must be
+    // the same account; otherwise a valid signature by A could be submitted as a
+    // login for B.
+    if (siwe.address.toLowerCase() !== address.toLowerCase()) {
+      return NextResponse.json({ error: 'Message address does not match' }, { status: 401 })
+    }
+
+    // `verifySiweMessage` re-checks the nonce, the domain, and the
+    // notBefore/expirationTime window, and resolves ERC-6492 / ERC-1271
+    // signatures so Base Account smart wallets verify correctly.
+    const isValid = await client.verifySiweMessage({
+      message,
+      signature: signature as `0x${string}`,
+      address: address as `0x${string}`,
+      domain,
+      nonce: siwe.nonce,
     })
-    
+
     if (!isValid) {
-      return NextResponse.json({ 
-        error: 'Invalid signature' 
-      }, { status: 401 })
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
     }
 
-    console.log('✅ Signature verified successfully for address:', address)
+    const sessionToken = createSessionToken(address)
+    if (!sessionToken) {
+      console.error('SESSION_SECRET is not set; refusing to issue an unsigned session')
+      return NextResponse.json({ error: 'Authentication is not configured' }, { status: 503 })
+    }
 
-    // Create session token (simplified - in production use proper JWT with SESSION_SECRET)
-    // For demo purposes, using simple encoding - in production, use proper JWT:
-    // const jwt = require('jsonwebtoken')
-    // const sessionToken = jwt.sign({ address, timestamp: Date.now() }, process.env.SESSION_SECRET)
-    const sessionToken = Buffer.from(`${address}:${Date.now()}`).toString('base64')
+    // The token is no longer echoed in the body. It is a bearer credential, and
+    // returning it invites client code to stash it somewhere reachable by script;
+    // the HttpOnly cookie is the only place it needs to live.
+    const response = NextResponse.json({ ok: true, address })
 
-    const response = NextResponse.json({ 
-      ok: true, 
-      address,
-      sessionToken 
-    })
-
-    // Set session cookie
-    response.cookies.set('session', sessionToken, {
+    response.cookies.set(SESSION_COOKIE_NAME, sessionToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'strict',
-      maxAge: 60 * 60 * 24 * 7 // 1 week
+      path: '/',
+      maxAge: SESSION_TTL_SECONDS
     })
 
     return response
@@ -79,14 +139,13 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET() {
-  // Generate a secure random nonce
-  const array = new Uint8Array(16)
-  crypto.getRandomValues(array)
-  const nonce = Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('')
-  
-  // Add to nonce store
-  nonces.add(nonce)
-  
-  console.log('Generated nonce:', nonce)
+  const nonce = issueNonce()
+  if (!nonce) {
+    console.error('SESSION_SECRET is not set; cannot issue a nonce')
+    return NextResponse.json({ error: 'Authentication is not configured' }, { status: 503 })
+  }
+
+  // The nonce is not logged. It is short-lived and unprivileged, but log lines
+  // are a poor place for anything that participates in an authentication flow.
   return NextResponse.json({ nonce })
 }

--- a/base-account/agent-spend-permissions/src/app/api/chat/route.ts
+++ b/base-account/agent-spend-permissions/src/app/api/chat/route.ts
@@ -1,11 +1,14 @@
+// src/app/api/chat/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { generateChatResponse, ChatMessage } from '@/lib/openai'
+import { readSessionAddress } from '@/lib/session'
 
 export async function POST(request: NextRequest) {
   try {
-    // Get session from cookie
-    const session = request.cookies.get('session')?.value
-    if (!session) {
+    // Verify the session cookie's signature rather than just checking that a
+    // cookie is present. The previous check accepted any non-empty value.
+    const userAddress = readSessionAddress(request)
+    if (!userAddress) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
     }
 

--- a/base-account/agent-spend-permissions/src/app/api/search/route.ts
+++ b/base-account/agent-spend-permissions/src/app/api/search/route.ts
@@ -1,9 +1,11 @@
+// src/app/api/search/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { createPublicClient, http, parseAbi } from 'viem'
 import { base } from 'viem/chains'
 import { toClientEvmSigner } from '@x402/evm'
 import { quoteSearchJobs, searchJobs, formatJobResults, flattenJobResults } from '@/lib/exa'
 import { getCdpClient, getServerWalletForUser } from '@/lib/cdp'
+import { readSessionAddress } from '@/lib/session'
 
 const USDC_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as const
 const USER_PULL_STEP_USDC = BigInt(100_000)
@@ -12,15 +14,6 @@ const BALANCE_VISIBILITY_DELAY_MS = 1_000
 const ERC20_ABI = parseAbi([
   'function balanceOf(address account) view returns (uint256)',
 ])
-
-function parseSessionUserAddress(session?: string): string | null {
-  if (!session) {
-    return null
-  }
-
-  const [userAddress] = Buffer.from(session, 'base64').toString().split(':')
-  return userAddress || null
-}
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -67,8 +60,12 @@ async function waitForUsdcBalanceAtLeast(
 
 export async function POST(request: NextRequest) {
   try {
-    const session = request.cookies.get('session')?.value
-    const userAddress = parseSessionUserAddress(session)
+    // This route spends the user's USDC on Base mainnet through their spend
+    // permission, keyed entirely by the session address. That address must come
+    // from a token this server signed — the previous `parseSessionUserAddress`
+    // base64-decoded an unsigned cookie, so any caller could name any address and
+    // drive that user's server wallet.
+    const userAddress = readSessionAddress(request)
 
     if (!userAddress) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
@@ -224,9 +221,12 @@ export async function POST(request: NextRequest) {
       smartAccountBalanceUSDC: Number(smartAccountBalance) / 1_000_000,
     })
   } catch (error) {
+    // Logged server-side only. Upstream x402, CDP and RPC errors carry wallet
+    // addresses, request identifiers and paymaster URLs, none of which belong in
+    // a response body.
     console.error('Job search error:', error)
     return NextResponse.json({
-      error: error instanceof Error ? error.message : 'Failed to search jobs',
+      error: 'Failed to search jobs',
     }, { status: 500 })
   }
 }

--- a/base-account/agent-spend-permissions/src/app/api/wallet/create/route.ts
+++ b/base-account/agent-spend-permissions/src/app/api/wallet/create/route.ts
@@ -1,18 +1,16 @@
+// src/app/api/wallet/create/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerWalletForUser, getServerWalletForUser } from '@/lib/cdp'
+import { readSessionAddress } from '@/lib/session'
 
 export async function POST(request: NextRequest) {
   try {
-    // Get session from cookie
-    const session = request.cookies.get('session')?.value
-    if (!session) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
-    }
-
-    // Decode user address from session (simplified)
-    const [userAddress] = Buffer.from(session, 'base64').toString().split(':')
+    // The address now comes from a signature-verified session token. Previously
+    // it was base64-decoded straight out of an unsigned cookie, so a caller could
+    // name any address and have a server wallet provisioned for it.
+    const userAddress = readSessionAddress(request)
     if (!userAddress) {
-      return NextResponse.json({ error: 'Invalid session' }, { status: 401 })
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
     }
 
     // Get or create server wallet for user
@@ -35,16 +33,10 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    // Get session from cookie
-    const session = request.cookies.get('session')?.value
-    if (!session) {
-      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
-    }
-
-    // Decode user address from session (simplified)
-    const [userAddress] = Buffer.from(session, 'base64').toString().split(':')
+    // Same signature-verified session as POST; see the note above.
+    const userAddress = readSessionAddress(request)
     if (!userAddress) {
-      return NextResponse.json({ error: 'Invalid session' }, { status: 401 })
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
     }
 
     // Get existing server wallet for user

--- a/base-account/agent-spend-permissions/src/lib/session.ts
+++ b/base-account/agent-spend-permissions/src/lib/session.ts
@@ -1,0 +1,149 @@
+// src/lib/session.ts
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import type { NextRequest } from 'next/server'
+
+/**
+ * Signed session tokens.
+ *
+ * The previous token was `base64(`${address}:${Date.now()}`)` — no signature, no
+ * key, nothing secret. Any visitor could compute
+ * `Buffer.from('0xVICTIM:1').toString('base64')`, set it as the `session` cookie
+ * and be treated as that address by every route that reads it. That made the
+ * SIWE verification in `/api/auth/verify` decorative: an attacker never needed to
+ * pass it.
+ *
+ * The cost was real. `/api/search` looks up a server wallet by the session
+ * address and spends that user's USDC on Base mainnet through their spend
+ * permission, and `/api/wallet/create` provisions and reveals server wallets for
+ * whichever address the cookie names.
+ *
+ * Tokens are now `v1.<payload>.<mac>` where `mac` is HMAC-SHA256 over the
+ * payload under `SESSION_SECRET`. The payload is still readable by the client —
+ * it is not secret — but it cannot be modified without the key.
+ */
+
+export const SESSION_COOKIE_NAME = 'session'
+
+const TOKEN_VERSION = 'v1'
+
+/** Matches the cookie `maxAge` set by `/api/auth/verify`. */
+export const SESSION_TTL_SECONDS = 60 * 60 * 24 * 7
+
+type SessionPayload = {
+  /** Lowercased address this session speaks for. */
+  address: string
+  /** Issued-at, in seconds since the epoch. */
+  iat: number
+}
+
+/**
+ * Returns the signing key, or `null` when `SESSION_SECRET` is unset.
+ *
+ * There is deliberately no fallback. A default or derived key would make the
+ * failure invisible, and an unsigned session here authorises mainnet spending.
+ * Callers must fail the request when this returns `null`.
+ */
+function getSigningKey(): Buffer | null {
+  const secret = process.env.SESSION_SECRET
+  if (!secret || secret.length < 16) {
+    return null
+  }
+  return Buffer.from(secret, 'utf8')
+}
+
+export function isSessionConfigured(): boolean {
+  return getSigningKey() !== null
+}
+
+function base64UrlEncode(input: Buffer): string {
+  return input.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlDecode(input: string): Buffer {
+  return Buffer.from(input.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+}
+
+function macFor(body: string, key: Buffer): string {
+  return base64UrlEncode(createHmac('sha256', key).update(body).digest())
+}
+
+/** Constant-time comparison that tolerates length mismatches without throwing. */
+function macsMatch(a: string, b: string): boolean {
+  const left = Buffer.from(a, 'utf8')
+  const right = Buffer.from(b, 'utf8')
+  if (left.length !== right.length) {
+    return false
+  }
+  return timingSafeEqual(left, right)
+}
+
+/**
+ * Mints a session token for `address`.
+ *
+ * @returns The token, or `null` when `SESSION_SECRET` is unset.
+ */
+export function createSessionToken(address: string): string | null {
+  const key = getSigningKey()
+  if (!key) {
+    return null
+  }
+
+  const payload: SessionPayload = {
+    address: address.toLowerCase(),
+    iat: Math.floor(Date.now() / 1000),
+  }
+  const body = base64UrlEncode(Buffer.from(JSON.stringify(payload), 'utf8'))
+  return `${TOKEN_VERSION}.${body}.${macFor(body, key)}`
+}
+
+/** Verifies a token and returns the address it carries, or `null`. */
+export function verifySessionToken(token: string | undefined): string | null {
+  const key = getSigningKey()
+  if (!key || !token) {
+    return null
+  }
+
+  const parts = token.split('.')
+  if (parts.length !== 3 || parts[0] !== TOKEN_VERSION) {
+    return null
+  }
+  const [, body, mac] = parts
+
+  // The MAC is checked before the payload is parsed, so untrusted bytes never
+  // reach JSON.parse.
+  if (!macsMatch(mac, macFor(body, key))) {
+    return null
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(base64UrlDecode(body).toString('utf8'))
+  } catch {
+    return null
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null
+  }
+
+  const { address, iat } = parsed as Partial<SessionPayload>
+  if (typeof address !== 'string' || typeof iat !== 'number') {
+    return null
+  }
+  if (!/^0x[0-9a-f]{40}$/.test(address)) {
+    return null
+  }
+
+  // Expiry is enforced here as well as by the cookie's Max-Age, which a client
+  // is free to ignore.
+  const ageSeconds = Math.floor(Date.now() / 1000) - iat
+  if (!Number.isFinite(ageSeconds) || ageSeconds < 0 || ageSeconds > SESSION_TTL_SECONDS) {
+    return null
+  }
+
+  return address
+}
+
+/** Reads and verifies the session cookie on a request. */
+export function readSessionAddress(request: NextRequest): string | null {
+  return verifySessionToken(request.cookies.get(SESSION_COOKIE_NAME)?.value)
+}

--- a/base-account/agent-spend-permissions/src/lib/siwe-nonce.ts
+++ b/base-account/agent-spend-permissions/src/lib/siwe-nonce.ts
@@ -1,0 +1,143 @@
+// src/lib/siwe-nonce.ts
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+
+/**
+ * Self-authenticating SIWE nonces.
+ *
+ * The previous implementation kept issued nonces in a module-level
+ * `Set<string>`. Three problems:
+ *
+ *   1. On any serverless or multi-instance deployment the instance that issued a
+ *      nonce is usually not the one that verifies it, so sign-in failed
+ *      intermittently for reasons that look like a wallet bug.
+ *   2. The set only ever grew. Every unused `GET /api/auth/verify` leaked 32
+ *      bytes for the lifetime of the process, and the endpoint is unauthenticated.
+ *   3. Nonces never expired, so a signature captured at any point in the past
+ *      stayed replayable for as long as the process lived.
+ *
+ * A nonce now carries its own expiry and a MAC over both halves, so any instance
+ * holding `SESSION_SECRET` can validate it without shared state. Single-use is
+ * additionally enforced per-instance on a best-effort basis; strict cluster-wide
+ * single-use needs a shared store, and the short lifetime is what bounds the
+ * replay window in the meantime.
+ *
+ * The encoding is pure lowercase hex because SIWE requires the nonce field to be
+ * alphanumeric — base64url would be rejected by a conforming parser.
+ */
+
+/** How long a nonce stays valid. Long enough to sign, short enough to matter. */
+const NONCE_TTL_SECONDS = 10 * 60
+
+const RANDOM_HEX_LENGTH = 32 // 16 bytes
+const EXPIRY_HEX_LENGTH = 8 // uint32 seconds since the epoch
+const MAC_HEX_LENGTH = 32 // 16 bytes of HMAC-SHA256, truncated
+
+export const NONCE_LENGTH = RANDOM_HEX_LENGTH + EXPIRY_HEX_LENGTH + MAC_HEX_LENGTH
+
+/** Nonces already redeemed on this instance. Bounded; see {@link rememberUsed}. */
+const usedNonces = new Map<string, number>()
+const MAX_REMEMBERED_NONCES = 10_000
+
+function getKey(): Buffer | null {
+  const secret = process.env.SESSION_SECRET
+  if (!secret || secret.length < 16) {
+    return null
+  }
+  // Domain-separated from the session token MAC so the two cannot be
+  // substituted for one another.
+  return createHmac('sha256', secret).update('siwe-nonce-v1').digest()
+}
+
+function macFor(body: string, key: Buffer): string {
+  return createHmac('sha256', key).update(body).digest('hex').slice(0, MAC_HEX_LENGTH)
+}
+
+function macsMatch(a: string, b: string): boolean {
+  const left = Buffer.from(a, 'utf8')
+  const right = Buffer.from(b, 'utf8')
+  if (left.length !== right.length) {
+    return false
+  }
+  return timingSafeEqual(left, right)
+}
+
+/**
+ * Issues a nonce, or `null` when `SESSION_SECRET` is unset.
+ *
+ * The returned string is alphanumeric and safe to embed in a SIWE message.
+ */
+export function issueNonce(): string | null {
+  const key = getKey()
+  if (!key) {
+    return null
+  }
+
+  const random = randomBytes(RANDOM_HEX_LENGTH / 2).toString('hex')
+  const expiry = Math.floor(Date.now() / 1000) + NONCE_TTL_SECONDS
+  const expiryHex = expiry.toString(16).padStart(EXPIRY_HEX_LENGTH, '0')
+  const body = `${random}${expiryHex}`
+
+  return `${body}${macFor(body, key)}`
+}
+
+/** Drops expired entries, then caps the table so it cannot grow without bound. */
+function rememberUsed(nonce: string, expiry: number): void {
+  const now = Math.floor(Date.now() / 1000)
+  const stale: string[] = []
+  usedNonces.forEach((entryExpiry: number, entry: string) => {
+    if (entryExpiry <= now) {
+      stale.push(entry)
+    }
+  })
+  stale.forEach((entry) => usedNonces.delete(entry))
+
+  if (usedNonces.size >= MAX_REMEMBERED_NONCES) {
+    // Every remaining entry is still live, so evict the oldest rather than
+    // refusing to record this one. Worst case a very old nonce becomes replayable
+    // within its remaining lifetime; refusing to record at all would make every
+    // nonce replayable.
+    const oldest = Array.from(usedNonces.keys())[0]
+    if (oldest !== undefined) {
+      usedNonces.delete(oldest)
+    }
+  }
+
+  usedNonces.set(nonce, expiry)
+}
+
+export type NonceCheck = 'ok' | 'malformed' | 'expired' | 'reused' | 'unavailable'
+
+/**
+ * Validates a nonce and marks it used.
+ *
+ * @returns `'ok'` only when the nonce was issued by this deployment, has not
+ *  expired, and has not already been redeemed on this instance.
+ */
+export function consumeNonce(nonce: unknown): NonceCheck {
+  const key = getKey()
+  if (!key) {
+    return 'unavailable'
+  }
+  if (typeof nonce !== 'string' || nonce.length !== NONCE_LENGTH || !/^[0-9a-f]+$/.test(nonce)) {
+    return 'malformed'
+  }
+
+  const body = nonce.slice(0, RANDOM_HEX_LENGTH + EXPIRY_HEX_LENGTH)
+  const mac = nonce.slice(RANDOM_HEX_LENGTH + EXPIRY_HEX_LENGTH)
+  if (!macsMatch(mac, macFor(body, key))) {
+    // Not issued here, or tampered with. Same answer either way.
+    return 'malformed'
+  }
+
+  const expiry = parseInt(nonce.slice(RANDOM_HEX_LENGTH, RANDOM_HEX_LENGTH + EXPIRY_HEX_LENGTH), 16)
+  if (!Number.isFinite(expiry) || expiry <= Math.floor(Date.now() / 1000)) {
+    return 'expired'
+  }
+
+  if (usedNonces.has(nonce)) {
+    return 'reused'
+  }
+  rememberUsed(nonce, expiry)
+
+  return 'ok'
+}


### PR DESCRIPTION
### Description
This pull request completely overhauls the session and authentication layer of `agent-spend-permissions` to close multiple critical and high-severity access control vulnerabilities (F-02, F-04)[cite: 30]. Previously, the application authorized mainnet USDC spending based on an unsigned, trivial-to-forge base64 session token, and verified SIWE signatures without asserting domain bindings or tracking nonces safely[cite: 30].

### Key Changes & Remediations

#### 1. Forgeable Session Mitigation (F-02)
* **Cryptographic Signatures:** The application no longer relies on an unsigned `Buffer.from("0xADDRESS:TIMESTAMP").toString('base64')` cookie to authorize operations[cite: 30]. `src/lib/session.ts` now wraps payloads with a strict `v1.<payload>.<mac>` standard authenticated by a constant-time HMAC-SHA256 signature using a mandatory `SESSION_SECRET`[cite: 30].
* **Route Protection:** All endpoints (`/api/wallet/create`, `/api/search`, `/api/chat`) that manipulate or spend on behalf of server wallets have been strictly transitioned to read exclusively from the new, signature-verified tokens[cite: 30].

#### 2. SIWE Verification Hardening (F-04)
* **ERC-6492 / ERC-1271 Support:** The `verify` route now utilizes `viem`'s `parseSiweMessage` and `verifySiweMessage` rather than a weak regex match[cite: 30]. This fully supports Smart Wallet signature recovery while correctly checking issue/expiry timestamps[cite: 30].
* **Domain Binding:** `SIWE_DOMAIN` enforcement (or `Host` header fallback) guarantees signatures obtained for other sites can no longer be replayed here[cite: 30].

#### 3. Stateless Nonces & Memory Leak Prevention (F-04)
* **Self-Authenticating Nonces:** Replaced the previous module-level `Set<string>` — which introduced severe memory leaks and erratic cross-instance sign-in failures — with stateless, HMAC-verified nonces that carry their own built-in `uint32` expiry[cite: 30]. 
* **Safe Replay Bounds:** Tracked nonces are opportunistically pruned and safely bounded to `10,000` concurrent uses to prevent memory exhaustion vectors.