### PR TITLE
feat(200ms-demo): stream over websocket

### DIFF
--- a/200ms-demo/README.md
+++ b/200ms-demo/README.md
@@ -70,8 +70,8 @@ The five-minute funding/throughput soak is available as `npm run soak`.
 - `src/chain/bootstrap.ts` — health, live contracts, persisted account,
   cooldown-aware funding, deployment proof, and one-time gas calibration.
 - `src/chain/streamer.ts` — exact rational accumulator, 200ms scheduler,
-  nonce-free signing, pending backpressure, receipt watcher, rebroadcast,
-  funding daemon, and reset detection.
+  nonce-free signing, WebSocket inclusion feed, low-rate balance reconciliation,
+  fallback receipt checks, rebroadcast, funding daemon, and reset detection.
 - `src/hooks/useStream.ts` — requestAnimationFrame sampling over the mutable
   streamer snapshot.
 - `src/ui/` — counter, real balance cards, rate selector, and explorer-linked

--- a/200ms-demo/src/App.tsx
+++ b/200ms-demo/src/App.tsx
@@ -22,8 +22,14 @@ const progressLabels: Record<BootstrapProgress['stage'], string> = {
   ready: 'Ready',
 }
 
-function Header({ phase }: { phase?: string }) {
-  const { head, cadenceMs } = useChainHead()
+function Header({ phase, streamHead, streamCadenceMs }: {
+  phase?: string
+  streamHead?: number
+  streamCadenceMs?: number | null
+}) {
+  const observed = useChainHead(streamHead === undefined)
+  const head = streamHead ?? observed.head
+  const cadenceMs = streamCadenceMs ?? observed.cadenceMs
   const live = head !== null
   return (
     <header className="site-header">
@@ -164,7 +170,7 @@ export default function App() {
 
   return (
     <div className="app-shell">
-      <Header phase={snapshot.phase} />
+      <Header phase={snapshot.phase} streamHead={snapshot.head} streamCadenceMs={snapshot.cadenceMs} />
       <main className="stream-layout">
         <section className="hero-section">
           <StreamCounter

--- a/200ms-demo/src/chain/config.ts
+++ b/200ms-demo/src/chain/config.ts
@@ -4,14 +4,17 @@ export const CHAIN_ID = 84_538_453
 export const NETWORK_NAME = 'Base Vibenet'
 export const API_URL = 'https://api.vibes.base.org'
 export const EXECUTION_RPC = 'https://rpc.vibes.base.org'
+export const EXECUTION_WS = 'wss://rpc.vibes.base.org/ws'
 export const ACCOUNT_RPC = `${API_URL}/api/vibenet/account/rpc`
 export const EXPLORER_URL = 'https://chain.base.org/vibenet/explorer'
 
 export const TOKEN_DECIMALS = 6
 export const TICK_MS = 200
-export const WATCH_MS = 400
-export const HEAD_POLL_MS = 1_000
-export const FUNDING_POLL_MS = 5_000
+/** Receipt reconciliation only when WebSocket delivery is unavailable. */
+export const FALLBACK_RECEIPT_POLL_MS = 500
+/** Low-rate balance, funding, and reset reconciliation while WebSocket delivery is healthy. */
+export const STATE_POLL_MS = 30_000
+export const FUNDING_POLL_MS = STATE_POLL_MS
 export const MAX_PENDING = 12
 export const MAX_TICKER_ROWS = 40
 export const PENDING_UNKNOWN_MS = 30_000

--- a/200ms-demo/src/chain/faucet.ts
+++ b/200ms-demo/src/chain/faucet.ts
@@ -1,7 +1,7 @@
 import type { Address, Hex } from '@vibenet/aa'
 
 import { MIN_ETH_BOOTSTRAP, USDV_TOP_UP_THRESHOLD, type FaucetStatus } from './config'
-import { postFaucet, readEthBalance, readTokenBalance } from './rpc'
+import { postFaucet, readEthBalance, readTokenBalance, type RpcRequester } from './rpc'
 
 const LAST_DRIP_KEY = 'base.200ms-demo.faucet.last.v1'
 const sleep = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms))
@@ -14,6 +14,7 @@ export type FaucetEvent = {
 export class FaucetQueue {
   private tail = Promise.resolve()
   private nextAllowedAt = 0
+  private requester: RpcRequester | undefined
 
   constructor(
     readonly status: FaucetStatus,
@@ -28,12 +29,16 @@ export class FaucetQueue {
     }
   }
 
+  setRequester(requester: RpcRequester | undefined) {
+    this.requester = requester
+  }
+
   ensureEth(address: Address, minimum = MIN_ETH_BOOTSTRAP): Promise<Hex | null> {
     return this.enqueue(async () => {
-      const before = await readEthBalance(address)
+      const before = await readEthBalance(address, 'latest', this.requester)
       if (before >= minimum) return null
       const response = await this.drip('/drip', address)
-      await this.waitForIncrease(() => readEthBalance(address), before, 'ETH faucet balance')
+      await this.waitForIncrease(() => readEthBalance(address, 'latest', this.requester), before, 'ETH faucet balance')
       this.onEvent?.({ kind: 'eth', hash: response.tx_hash })
       return response.tx_hash
     })
@@ -41,10 +46,10 @@ export class FaucetQueue {
 
   ensureUsdv(address: Address, minimum = USDV_TOP_UP_THRESHOLD): Promise<Hex | null> {
     return this.enqueue(async () => {
-      const before = await readTokenBalance(this.token, address)
+      const before = await readTokenBalance(this.token, address, 'latest', this.requester)
       if (before >= minimum) return null
       const response = await this.drip('/drip-usdv', address)
-      await this.waitForIncrease(() => readTokenBalance(this.token, address), before, 'USDV faucet balance')
+      await this.waitForIncrease(() => readTokenBalance(this.token, address, 'latest', this.requester), before, 'USDV faucet balance')
       this.onEvent?.({ kind: 'usdv', hash: response.tx_hash })
       return response.tx_hash
     })

--- a/200ms-demo/src/chain/rpc.ts
+++ b/200ms-demo/src/chain/rpc.ts
@@ -60,6 +60,10 @@ export async function fetchJson<T>(url: string, init: RequestInit = {}, timeoutM
   }
 }
 
+export type RpcRequester = {
+  request<T = unknown>(method: string, params?: unknown[]): Promise<T>
+}
+
 let rpcId = 0
 export async function rpc<T = unknown>(
   method: string,
@@ -85,6 +89,15 @@ export async function rpc<T = unknown>(
   return body.result as T
 }
 
+async function requestFrom<T>(requester: RpcRequester | undefined, method: string, params: unknown[], endpoint?: string) {
+  if (!requester) return rpc<T>(method, params, endpoint)
+  try {
+    return await requester.request<T>(method, params)
+  } catch {
+    return rpc<T>(method, params, endpoint)
+  }
+}
+
 export const getChainHealth = () => fetchJson<ChainHealth>(`${API_URL}/api/vibenet/chain-health`)
 export const getContracts = () => fetchJson<LiveContracts>(`${API_URL}/api/vibenet/contracts`)
 export const getFaucetStatus = () => fetchJson<FaucetStatus>(`${API_URL}/api/vibenet/faucet/status`)
@@ -100,63 +113,81 @@ export async function postFaucet(path: '/drip' | '/drip-usdv', address: Address)
   )
 }
 
-export async function readCode(address: Address): Promise<Hex> {
-  return rpc<Hex>('eth_getCode', [address, 'latest'])
+export async function readCode(address: Address, requester?: RpcRequester): Promise<Hex> {
+  return requestFrom<Hex>(requester, 'eth_getCode', [address, 'latest'])
 }
 
-export async function readGenesisHash(): Promise<Hex> {
-  const block = await rpc<{ hash: Hex }>('eth_getBlockByNumber', ['0x0', false])
+export async function readGenesisHash(requester?: RpcRequester): Promise<Hex> {
+  const block = await requestFrom<{ hash: Hex }>(requester, 'eth_getBlockByNumber', ['0x0', false])
   if (!block?.hash) throw new Error('Vibenet returned no genesis hash')
   return block.hash
 }
 
-export async function readHead(): Promise<number> {
-  return Number(BigInt(await rpc<Hex>('eth_blockNumber')))
+export async function readLatestBlock(requester?: RpcRequester): Promise<{ number: Hex; hash: Hex; baseFeePerGas?: Hex }> {
+  return requestFrom(requester, 'eth_getBlockByNumber', ['latest', false])
 }
 
-export async function readLatestBlock(): Promise<{ number: Hex; hash: Hex; baseFeePerGas?: Hex }> {
-  return rpc('eth_getBlockByNumber', ['latest', false])
-}
-
-export async function readEthBalance(address: Address, blockTag: Hex | 'latest' = 'latest'): Promise<bigint> {
-  return BigInt(await rpc<Hex>('eth_getBalance', [address, blockTag]))
+export async function readEthBalance(
+  address: Address,
+  blockTag: Hex | 'latest' = 'latest',
+  requester?: RpcRequester,
+): Promise<bigint> {
+  return BigInt(await requestFrom<Hex>(requester, 'eth_getBalance', [address, blockTag]))
 }
 
 export async function readTokenBalance(
   token: Address,
   address: Address,
   blockTag: Hex | 'latest' = 'latest',
+  requester?: RpcRequester,
 ): Promise<bigint> {
   const data = encodeFunctionData({ abi: erc20Abi, functionName: 'balanceOf', args: [address] })
-  const raw = await rpc<Hex>('eth_call', [{ to: token, data }, blockTag])
+  const raw = await requestFrom<Hex>(requester, 'eth_call', [{ to: token, data }, blockTag])
   return decodeAbiParameters([{ type: 'uint256' }], raw)[0] as bigint
 }
 
-export async function readFreshBalances(token: Address, sender: Address, recipient: Address) {
-  const blockNumber = await rpc<Hex>('eth_blockNumber')
+export async function readFreshBalances(
+  token: Address,
+  sender: Address,
+  recipient: Address,
+  requester?: RpcRequester,
+) {
+  const blockNumber = await requestFrom<Hex>(requester, 'eth_blockNumber', [])
   try {
     const [eth, senderToken, recipientToken] = await Promise.all([
-      readEthBalance(sender, blockNumber),
-      readTokenBalance(token, sender, blockNumber),
-      readTokenBalance(token, recipient, blockNumber),
+      readEthBalance(sender, blockNumber, requester),
+      readTokenBalance(token, sender, blockNumber, requester),
+      readTokenBalance(token, recipient, blockNumber, requester),
     ])
     return { blockNumber: Number(BigInt(blockNumber)), eth, senderToken, recipientToken }
   } catch {
     const [eth, senderToken, recipientToken] = await Promise.all([
-      readEthBalance(sender),
-      readTokenBalance(token, sender),
-      readTokenBalance(token, recipient),
+      readEthBalance(sender, 'latest', requester),
+      readTokenBalance(token, sender, 'latest', requester),
+      readTokenBalance(token, recipient, 'latest', requester),
     ])
     return { blockNumber: Number(BigInt(blockNumber)), eth, senderToken, recipientToken }
   }
 }
 
-export async function readReceipt(hash: Hex) {
-  return getTransactionReceipt(publicClient, { hash }).catch(() => null)
+export async function readReceipt(hash: Hex, requester?: RpcRequester) {
+  if (requester) {
+    try {
+      return await requester.request<Record<string, any> | null>('eth_getTransactionReceipt', [hash])
+    } catch {
+      return readReceipt(hash)
+    }
+  }
+  try {
+    return await getTransactionReceipt(publicClient, { hash })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'TransactionReceiptNotFoundError') return null
+    throw error
+  }
 }
 
-export async function readTransaction(hash: Hex) {
-  return rpc<Record<string, unknown> | null>('eth_getTransactionByHash', [hash])
+export async function readTransaction(hash: Hex, requester?: RpcRequester) {
+  return requestFrom<Record<string, unknown> | null>(requester, 'eth_getTransactionByHash', [hash])
 }
 
 export async function sendRaw(raw: Hex): Promise<Hex> {

--- a/200ms-demo/src/chain/streamSocket.ts
+++ b/200ms-demo/src/chain/streamSocket.ts
@@ -1,0 +1,174 @@
+import type { Address, Hex } from '@vibenet/aa'
+
+import { EXECUTION_WS } from './config'
+import type { RpcRequester } from './rpc'
+import type { ChainHead, TransferLog } from './subscriptions'
+
+type RpcError = { code?: number; message?: string }
+type PendingRequest = {
+  resolve: (value: any) => void
+  reject: (error: Error) => void
+  timer: number
+}
+
+type StreamSocketOptions = {
+  token: Address
+  sender: Address
+  recipient: Address
+  onLog: (log: TransferLog) => void
+  onHead: (head: ChainHead) => void
+  onState: (state: 'connecting' | 'live' | 'retrying') => void
+}
+
+export type StreamSocket = RpcRequester & {
+  sendRaw(raw: Hex): Promise<Hex>
+  close(): void
+}
+
+const transferTopic = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' as Hex
+
+function addressTopic(address: Address): Hex {
+  return `0x${address.slice(2).padStart(64, '0')}` as Hex
+}
+
+/** One persistent WSS connection for streaming RPC requests and chain notifications. */
+export function openStreamSocket(options: StreamSocketOptions): StreamSocket {
+  let socket: WebSocket | null = null
+  let opening: Promise<WebSocket> | null = null
+  let reconnectTimer: number | null = null
+  let attempts = 0
+  let stopped = false
+  let logSubscriptionId: string | null = null
+  let headSubscriptionId: string | null = null
+  let nextId = 2
+  const pending = new Map<number, PendingRequest>()
+
+  const rejectPending = (error: Error) => {
+    for (const request of pending.values()) {
+      window.clearTimeout(request.timer)
+      request.reject(error)
+    }
+    pending.clear()
+  }
+
+  const scheduleReconnect = () => {
+    if (stopped || reconnectTimer !== null) return
+    attempts += 1
+    const delay = Math.min(5_000, 250 * 2 ** Math.min(attempts, 4))
+    reconnectTimer = window.setTimeout(() => {
+      reconnectTimer = null
+      void connect().catch(() => undefined)
+    }, delay)
+  }
+
+  const connect = (): Promise<WebSocket> => {
+    if (socket?.readyState === WebSocket.OPEN) return Promise.resolve(socket)
+    if (opening) return opening
+
+    options.onState(attempts === 0 ? 'connecting' : 'retrying')
+    opening = new Promise<WebSocket>((resolve, reject) => {
+      const nextSocket = new WebSocket(EXECUTION_WS)
+      socket = nextSocket
+      let opened = false
+      const failOpen = () => {
+        if (!opened) reject(new Error('Vibenet stream WebSocket failed to connect'))
+      }
+
+      nextSocket.addEventListener('open', () => {
+        opened = true
+        nextSocket.send(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_subscribe',
+          params: ['logs', {
+            address: options.token,
+            topics: [transferTopic, addressTopic(options.sender), addressTopic(options.recipient)],
+          }],
+        }))
+        nextSocket.send(JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'eth_subscribe', params: ['newHeads'] }))
+        resolve(nextSocket)
+      }, { once: true })
+
+      nextSocket.addEventListener('message', (event) => {
+        let message: { id?: number; result?: any; error?: RpcError; method?: string; params?: any }
+        try {
+          message = JSON.parse(String(event.data))
+        } catch {
+          return
+        }
+        if (message.id === 1) {
+          if (message.error || typeof message.result !== 'string') nextSocket.close()
+          else {
+            logSubscriptionId = message.result
+            attempts = 0
+            options.onState('live')
+          }
+          return
+        }
+        if (message.id === 2) {
+          if (message.error || typeof message.result !== 'string') nextSocket.close()
+          else headSubscriptionId = message.result
+          return
+        }
+        if (typeof message.id === 'number') {
+          const request = pending.get(message.id)
+          if (!request) return
+          pending.delete(message.id)
+          window.clearTimeout(request.timer)
+          if (message.error) request.reject(new Error(message.error.message ?? 'WebSocket JSON-RPC request failed'))
+          else request.resolve(message.result)
+          return
+        }
+        if (message.method !== 'eth_subscription') return
+        if (message.params?.subscription === logSubscriptionId) {
+          const log = message.params.result
+          if (log?.removed || typeof log?.transactionHash !== 'string' || typeof log?.blockNumber !== 'string') return
+          options.onLog({ transactionHash: log.transactionHash as Hex, blockNumber: Number(BigInt(log.blockNumber)) })
+        } else if (message.params?.subscription === headSubscriptionId) {
+          const head = message.params.result
+          if (typeof head?.number === 'string') options.onHead({ number: Number(BigInt(head.number)) })
+        }
+      })
+
+      nextSocket.addEventListener('error', () => nextSocket.close(), { once: true })
+      nextSocket.addEventListener('close', () => {
+        if (socket === nextSocket) socket = null
+        logSubscriptionId = null
+        headSubscriptionId = null
+        rejectPending(new Error('Vibenet stream WebSocket closed'))
+        if (!stopped) options.onState('retrying')
+        failOpen()
+        scheduleReconnect()
+      }, { once: true })
+    }).finally(() => { opening = null })
+
+    return opening
+  }
+
+  const request = async <T>(method: string, params: unknown[] = []): Promise<T> => {
+    const activeSocket = await connect()
+    const id = ++nextId
+    return new Promise<T>((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        pending.delete(id)
+        reject(new Error(`${method} timed out over WebSocket`))
+      }, 3_000)
+      pending.set(id, { resolve, reject, timer })
+      activeSocket.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+    })
+  }
+
+  void connect().catch(() => undefined)
+  return {
+    request,
+    sendRaw: (raw) => request<Hex>('eth_sendRawTransaction', [raw]),
+    close: () => {
+      stopped = true
+      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer)
+      reconnectTimer = null
+      socket?.close()
+      socket = null
+      rejectPending(new Error('Vibenet stream WebSocket closed'))
+    },
+  }
+}

--- a/200ms-demo/src/chain/streamer.ts
+++ b/200ms-demo/src/chain/streamer.ts
@@ -14,13 +14,14 @@ import {
   erc20Abi,
   ETH_TOP_UP_THRESHOLD,
   FUNDING_POLL_MS,
+  FALLBACK_RECEIPT_POLL_MS,
   MAX_PENDING,
   MAX_TICKER_ROWS,
   NONCE_FREE_VALIDITY_MS,
   PENDING_UNKNOWN_MS,
   TICK_MS,
+  STATE_POLL_MS,
   USDV_TOP_UP_THRESHOLD,
-  WATCH_MS,
   type StreamRate,
 } from './config'
 import type { StreamRuntime } from './bootstrap'
@@ -30,11 +31,14 @@ import {
   isRecoverableBroadcastError,
   readCode,
   readFreshBalances,
+  readGenesisHash,
   readLatestBlock,
   readReceipt,
   readTransaction,
   sendRaw,
 } from './rpc'
+import type { TransferLog } from './subscriptions'
+import { openStreamSocket, type StreamSocket } from './streamSocket'
 
 export type StreamPhase = 'idle' | 'streaming' | 'paused' | 'stopping' | 'stopped' | 'error'
 export type TransactionStatus = 'pending' | 'confirmed' | 'reverted' | 'unknown'
@@ -43,8 +47,10 @@ export type StreamTransaction = {
   hash: Hex
   amount: bigint
   status: TransactionStatus
-  sentAt: number
+  /** Monotonic timestamp captured after the RPC acknowledges the transaction. */
+  acceptedAt: number
   blockNumber?: number
+  /** Client-observed time from RPC acknowledgement to block/receipt observation. */
   latencyMs?: number
   message?: string
 }
@@ -102,10 +108,12 @@ export class MoneyStreamer {
   private sending = false
   private destroyed = false
   private watcherRunning = false
+  private transferFeedLive = false
+  private readonly streamSocket: StreamSocket
   private fundingRunning = false
   private receiptConfirmedUnits = 0n
   private lastHeadSeenAt = performance.now()
-  private lastIntegrityCheckAt = 0
+  private lastStateSyncAt = -Infinity
   private transactionOrdinal = 0
   private readonly sessionId = crypto.randomUUID()
 
@@ -134,6 +142,19 @@ export class MoneyStreamer {
       errorCode: null,
     }
     document.addEventListener('visibilitychange', this.handleVisibility)
+    this.streamSocket = openStreamSocket({
+      token: runtime.token,
+      sender: runtime.identity.account.address,
+      recipient: runtime.identity.recipient,
+      onLog: this.handleTransferLog,
+      onHead: this.handleHead,
+      onState: (state) => {
+        const wasLive = this.transferFeedLive
+        this.transferFeedLive = state === 'live'
+        if (wasLive && !this.transferFeedLive) this.scheduleWatcher(0)
+      },
+    })
+    runtime.faucet.setRequester(this.streamSocket)
     this.scheduleWatcher(0)
     this.scheduleFunding(FUNDING_POLL_MS)
   }
@@ -202,6 +223,7 @@ export class MoneyStreamer {
     if (this.watchTimer !== null) window.clearTimeout(this.watchTimer)
     if (this.fundingTimer !== null) window.clearTimeout(this.fundingTimer)
     this.lease.release()
+    this.streamSocket.close()
     document.removeEventListener('visibilitychange', this.handleVisibility)
     this.listeners.clear()
   }
@@ -288,15 +310,15 @@ export class MoneyStreamer {
       })
       const hash = keccak256(raw)
       const acceptedHash = await this.broadcast(raw, hash)
-      const sentAt = Date.now()
+      const acceptedAt = performance.now()
       const transaction: PendingTransaction = {
         hash: acceptedHash,
         raw,
         amount,
         status: 'pending',
-        sentAt,
+        acceptedAt,
         validBefore,
-        lastBroadcastAt: performance.now(),
+        lastBroadcastAt: acceptedAt,
       }
       this.pending.set(hash.toLowerCase(), transaction)
       this.patch({
@@ -314,11 +336,20 @@ export class MoneyStreamer {
     }
   }
 
+  private async submitRaw(raw: Hex): Promise<Hex> {
+    try {
+      return await this.streamSocket.sendRaw(raw)
+    } catch {
+      return sendRaw(raw)
+    }
+  }
+
+
   private async broadcast(raw: Hex, expectedHash: Hex): Promise<Hex> {
     let lastError: unknown
     for (let attempt = 0; attempt < 4; attempt += 1) {
       try {
-        const returnedHash = await sendRaw(raw)
+        const returnedHash = await this.submitRaw(raw)
         if (returnedHash.toLowerCase() !== expectedHash.toLowerCase()) {
           throw new Error(`RPC returned an unexpected transaction hash`)
         }
@@ -326,8 +357,8 @@ export class MoneyStreamer {
       } catch (error) {
         lastError = error
         const [transaction, receipt] = await Promise.all([
-          readTransaction(expectedHash).catch(() => null),
-          readReceipt(expectedHash),
+          readTransaction(expectedHash, this.streamSocket).catch(() => null),
+          readReceipt(expectedHash, this.streamSocket).catch(() => null),
         ])
         if (transaction || receipt) return expectedHash
         if (!isRecoverableBroadcastError(error) && attempt >= 1) throw error
@@ -337,7 +368,7 @@ export class MoneyStreamer {
     throw lastError instanceof Error ? lastError : new Error('Transaction broadcast failed')
   }
 
-  private scheduleWatcher(delay = WATCH_MS) {
+  private scheduleWatcher(delay = this.transferFeedLive ? STATE_POLL_MS : FALLBACK_RECEIPT_POLL_MS) {
     if (this.destroyed) return
     if (this.watchTimer !== null) window.clearTimeout(this.watchTimer)
     this.watchTimer = window.setTimeout(() => void this.watch(), delay)
@@ -347,60 +378,19 @@ export class MoneyStreamer {
     if (this.watcherRunning || this.destroyed) return this.scheduleWatcher()
     this.watcherRunning = true
     try {
-      const balances = await readFreshBalances(
-        this.runtime.token,
-        this.runtime.identity.account.address,
-        this.runtime.identity.recipient,
-      )
-      if (balances.blockNumber + 5 < this.snapshot.head) {
-        this.fail('Vibenet reset detected — creating a new stream account.', 'NETWORK_RESET')
-        return
-      }
-      if (balances.blockNumber > this.snapshot.head) {
-        const now = performance.now()
-        const blockDelta = balances.blockNumber - this.snapshot.head
-        const cadence = blockDelta > 0 ? (now - this.lastHeadSeenAt) / blockDelta : this.snapshot.cadenceMs
-        this.lastHeadSeenAt = now
-        this.snapshot = { ...this.snapshot, head: balances.blockNumber, cadenceMs: cadence }
-      }
-
-      const balanceConfirmedUnits = balances.recipientToken > this.runtime.recipientBaseline
-        ? balances.recipientToken - this.runtime.recipientBaseline
-        : 0n
-      if (balances.recipientToken < this.snapshot.recipientTokenBalance && this.snapshot.confirmedUnits > 0n) {
-        this.fail('Recipient balance rolled back — Vibenet reset detected.', 'NETWORK_RESET')
-        return
-      }
-      this.snapshot = {
-        ...this.snapshot,
-        confirmedUnits: balanceConfirmedUnits > this.receiptConfirmedUnits
-          ? balanceConfirmedUnits
-          : this.receiptConfirmedUnits,
-        senderEthBalance: balances.eth,
-        senderTokenBalance: balances.senderToken,
-        recipientTokenBalance: balances.recipientToken,
+      const now = performance.now()
+      if (now - this.lastStateSyncAt >= STATE_POLL_MS) {
+        this.lastStateSyncAt = now
+        if (!await this.refreshState()) return
       }
 
       const oldest = [...this.pending.values()]
-        .sort((left, right) => left.sentAt - right.sentAt)
+        .sort((left, right) => left.acceptedAt - right.acceptedAt)
         .slice(0, 10)
-      for (const transaction of oldest) await this.reconcile(transaction)
-
-      if (performance.now() - this.lastIntegrityCheckAt > 10_000) {
-        this.lastIntegrityCheckAt = performance.now()
-        const [implementationCode, tokenCode, health, latestBlock] = await Promise.all([
-          readCode(this.runtime.identity.implementation),
-          readCode(this.runtime.token),
-          getChainHealth(),
-          readLatestBlock(),
-        ])
-        if (implementationCode === '0x' || tokenCode === '0x' || !health.healthy) {
-          this.fail('Vibenet reset or maintenance detected — rebuilding the stream.', 'NETWORK_RESET')
-          return
-        }
-        const baseFee = BigInt(latestBlock.baseFeePerGas ?? 1_000_000_000n)
-        this.runtime.maxFeePerGas = baseFee * 2n + this.runtime.maxPriorityFeePerGas
-      }
+      const fallbackTransactions = this.transferFeedLive
+        ? oldest.filter((transaction) => performance.now() - transaction.acceptedAt > 3_000)
+        : oldest
+      for (const transaction of fallbackTransactions) await this.reconcile(transaction)
 
       this.recomputePending()
       if (this.snapshot.phase === 'stopping' && this.pending.size === 0 && !this.sending) {
@@ -417,13 +407,108 @@ export class MoneyStreamer {
     }
   }
 
+  private async refreshState(): Promise<boolean> {
+    const [balances, implementationCode, tokenCode, health, latestBlock, genesisHash] = await Promise.all([
+      readFreshBalances(
+        this.runtime.token,
+        this.runtime.identity.account.address,
+        this.runtime.identity.recipient,
+        this.streamSocket,
+      ),
+      readCode(this.runtime.identity.implementation, this.streamSocket),
+      readCode(this.runtime.token, this.streamSocket),
+      getChainHealth(),
+      readLatestBlock(this.streamSocket),
+      readGenesisHash(this.streamSocket),
+    ])
+    if (
+      implementationCode === '0x'
+      || tokenCode === '0x'
+      || !health.healthy
+      || genesisHash.toLowerCase() !== this.runtime.identity.genesisHash.toLowerCase()
+    ) {
+      this.fail('Vibenet reset or maintenance detected — rebuilding the stream.', 'NETWORK_RESET')
+      return false
+    }
+    if (balances.blockNumber > this.snapshot.head) {
+      const now = performance.now()
+      const blockDelta = balances.blockNumber - this.snapshot.head
+      const cadence = blockDelta > 0 ? (now - this.lastHeadSeenAt) / blockDelta : this.snapshot.cadenceMs
+      this.lastHeadSeenAt = now
+      this.snapshot = { ...this.snapshot, head: balances.blockNumber, cadenceMs: cadence }
+    }
+
+    const balanceConfirmedUnits = balances.recipientToken > this.runtime.recipientBaseline
+      ? balances.recipientToken - this.runtime.recipientBaseline
+      : 0n
+    this.snapshot = {
+      ...this.snapshot,
+      confirmedUnits: balanceConfirmedUnits > this.receiptConfirmedUnits
+        ? balanceConfirmedUnits
+        : this.receiptConfirmedUnits,
+      senderEthBalance: balances.eth,
+      senderTokenBalance: balances.senderToken > this.snapshot.senderTokenBalance
+        ? balances.senderToken
+        : this.snapshot.senderTokenBalance,
+      recipientTokenBalance: balances.recipientToken > this.snapshot.recipientTokenBalance
+        ? balances.recipientToken
+        : this.snapshot.recipientTokenBalance,
+    }
+    const baseFee = BigInt(latestBlock.baseFeePerGas ?? 1_000_000_000n)
+    this.runtime.maxFeePerGas = baseFee * 2n + this.runtime.maxPriorityFeePerGas
+    return true
+  }
+
+
+
+  private readonly handleHead = (head: { number: number }) => {
+    if (head.number <= this.snapshot.head) return
+    const observedAt = performance.now()
+    const blockDelta = head.number - this.snapshot.head
+    const cadence = (observedAt - this.lastHeadSeenAt) / blockDelta
+    this.lastHeadSeenAt = observedAt
+    this.snapshot = { ...this.snapshot, head: head.number, cadenceMs: cadence }
+    this.emit()
+  }
+
+
+  private readonly handleTransferLog = (log: TransferLog) => {
+    const transaction = this.pending.get(log.transactionHash.toLowerCase())
+    if (!transaction) return
+    const observedAt = performance.now()
+    this.pending.delete(log.transactionHash.toLowerCase())
+    this.receiptConfirmedUnits += transaction.amount
+    this.snapshot = {
+      ...this.snapshot,
+      head: Math.max(this.snapshot.head, log.blockNumber),
+      confirmedUnits: this.receiptConfirmedUnits > this.snapshot.confirmedUnits
+        ? this.receiptConfirmedUnits
+        : this.snapshot.confirmedUnits,
+      confirmedCount: this.snapshot.confirmedCount + 1,
+      senderTokenBalance: this.snapshot.senderTokenBalance > transaction.amount
+        ? this.snapshot.senderTokenBalance - transaction.amount
+        : 0n,
+      recipientTokenBalance: this.snapshot.recipientTokenBalance + transaction.amount,
+      transactions: this.replaceTransaction(transaction.hash, {
+        status: 'confirmed',
+        blockNumber: log.blockNumber,
+        latencyMs: observedAt - transaction.acceptedAt,
+      }),
+    }
+    this.emit()
+  }
   private async reconcile(transaction: PendingTransaction) {
-    const receipt = await readReceipt(transaction.hash)
+    const receipt = await readReceipt(transaction.hash, this.streamSocket)
+    const receiptObservedAt = performance.now()
+    if (!this.pending.has(transaction.hash.toLowerCase())) return
     if (receipt) {
       const succeeded = receiptSucceeded(receipt)
       const blockNumber = Number(BigInt(receipt.blockNumber))
-      const latencyMs = Date.now() - transaction.sentAt
       this.pending.delete(transaction.hash.toLowerCase())
+      const timing = {
+        blockNumber,
+        latencyMs: receiptObservedAt - transaction.acceptedAt,
+      }
       if (!succeeded) {
         this.snapshot = {
           ...this.snapshot,
@@ -431,8 +516,7 @@ export class MoneyStreamer {
           revertedCount: this.snapshot.revertedCount + 1,
           transactions: this.replaceTransaction(transaction.hash, {
             status: 'reverted',
-            blockNumber,
-            latencyMs,
+            ...timing,
             message: 'Call phase reverted; value returned to the accumulator',
           }),
         }
@@ -444,22 +528,26 @@ export class MoneyStreamer {
             ? this.receiptConfirmedUnits
             : this.snapshot.confirmedUnits,
           confirmedCount: this.snapshot.confirmedCount + 1,
+          senderTokenBalance: this.snapshot.senderTokenBalance > transaction.amount
+            ? this.snapshot.senderTokenBalance - transaction.amount
+            : 0n,
+          recipientTokenBalance: this.snapshot.recipientTokenBalance + transaction.amount,
           transactions: this.replaceTransaction(transaction.hash, {
             status: 'confirmed',
-            blockNumber,
-            latencyMs,
+            ...timing,
           }),
         }
       }
       return
     }
 
+
     const now = performance.now()
-    const chainTransaction = await readTransaction(transaction.hash).catch(() => null)
+    const chainTransaction = await readTransaction(transaction.hash, this.streamSocket).catch(() => null)
     if (!chainTransaction && Date.now() < transaction.validBefore - 500 && now - transaction.lastBroadcastAt > 700) {
       transaction.lastBroadcastAt = now
       try {
-        await sendRaw(transaction.raw)
+        await this.submitRaw(transaction.raw)
       } catch (error) {
         if (!isRecoverableBroadcastError(error)) {
           transaction.message = error instanceof Error ? error.message : 'Rebroadcast failed'
@@ -467,7 +555,7 @@ export class MoneyStreamer {
       }
     }
 
-    if (Date.now() - transaction.sentAt > PENDING_UNKNOWN_MS) {
+    if (performance.now() - transaction.acceptedAt > PENDING_UNKNOWN_MS) {
       this.pending.delete(transaction.hash.toLowerCase())
       this.snapshot = {
         ...this.snapshot,
@@ -490,7 +578,7 @@ export class MoneyStreamer {
   private recomputePending() {
     const values = [...this.pending.values()]
     const pendingUnits = values.reduce((sum, transaction) => sum + transaction.amount, 0n)
-    const latestPending = values.sort((left, right) => right.sentAt - left.sentAt)[0]
+    const latestPending = values.sort((left, right) => right.acceptedAt - left.acceptedAt)[0]
     this.snapshot = {
       ...this.snapshot,
       pendingUnits,
@@ -507,18 +595,25 @@ export class MoneyStreamer {
   private async fund() {
     if (this.fundingRunning || this.destroyed) return this.scheduleFunding()
     this.fundingRunning = true
+    let toppedUp = false
     try {
       if (this.snapshot.senderEthBalance < ETH_TOP_UP_THRESHOLD) {
         this.patch({ notice: 'Topping up gas automatically…' })
         await this.runtime.faucet.ensureEth(this.runtime.identity.account.address, ETH_TOP_UP_THRESHOLD)
+        toppedUp = true
       }
       if (this.snapshot.senderTokenBalance < USDV_TOP_UP_THRESHOLD) {
         this.patch({ notice: 'Topping up USDV automatically…' })
         await this.runtime.faucet.ensureUsdv(this.runtime.identity.account.address, USDV_TOP_UP_THRESHOLD)
+        toppedUp = true
       }
     } catch (error) {
       this.patch({ notice: error instanceof Error ? `Top-up retrying: ${error.message}` : 'Top-up retrying' })
     } finally {
+      if (toppedUp) {
+        this.lastStateSyncAt = -Infinity
+        this.scheduleWatcher(0)
+      }
       this.fundingRunning = false
       this.scheduleFunding()
     }
@@ -544,7 +639,7 @@ export class MoneyStreamer {
   private recomputePendingWithoutEmit() {
     const values = [...this.pending.values()]
     const pendingUnits = values.reduce((sum, transaction) => sum + transaction.amount, 0n)
-    const latestPending = values.sort((left, right) => right.sentAt - left.sentAt)[0]
+    const latestPending = values.sort((left, right) => right.acceptedAt - left.acceptedAt)[0]
     this.snapshot = {
       ...this.snapshot,
       pendingUnits,

--- a/200ms-demo/src/chain/subscriptions.ts
+++ b/200ms-demo/src/chain/subscriptions.ts
@@ -1,0 +1,59 @@
+import type { Hex } from '@vibenet/aa'
+
+import { EXECUTION_WS } from './config'
+
+export type TransferLog = {
+  transactionHash: Hex
+  blockNumber: number
+}
+
+export type ChainHead = {
+  number: number
+}
+
+/** Receives canonical head notifications for the header without eth_blockNumber polling. */
+export function subscribeToHeads(onHead: (head: ChainHead) => void): () => void {
+  let socket: WebSocket | null = null
+  let reconnectTimer: number | null = null
+  let attempts = 0
+  let stopped = false
+
+  const connect = () => {
+    if (stopped) return
+    socket = new WebSocket(EXECUTION_WS)
+    socket.addEventListener('open', () => {
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_subscribe', params: ['newHeads'] }))
+      }
+    })
+    socket.addEventListener('message', (event) => {
+      let message: any
+      try {
+        message = JSON.parse(String(event.data))
+      } catch {
+        return
+      }
+      if (message.id === 1 && message.error) {
+        socket?.close()
+        return
+      }
+      if (message.method !== 'eth_subscription' || typeof message.params?.result?.number !== 'string') return
+      onHead({ number: Number(BigInt(message.params.result.number)) })
+    })
+    socket.addEventListener('error', () => socket?.close())
+    socket.addEventListener('close', () => {
+      socket = null
+      if (stopped) return
+      attempts += 1
+      const delay = Math.min(5_000, 250 * 2 ** Math.min(attempts, 4))
+      reconnectTimer = window.setTimeout(connect, delay)
+    })
+  }
+
+  connect()
+  return () => {
+    stopped = true
+    if (reconnectTimer !== null) window.clearTimeout(reconnectTimer)
+    socket?.close()
+  }
+}

--- a/200ms-demo/src/hooks/useChainHead.ts
+++ b/200ms-demo/src/hooks/useChainHead.ts
@@ -1,38 +1,22 @@
 import { useEffect, useRef, useState } from 'react'
 
-import { HEAD_POLL_MS } from '../chain/config'
-import { readHead } from '../chain/rpc'
+import { subscribeToHeads } from '../chain/subscriptions'
 
-export function useChainHead() {
+export function useChainHead(enabled = true) {
   const [head, setHead] = useState<number | null>(null)
   const [cadenceMs, setCadenceMs] = useState<number | null>(null)
   const previous = useRef<{ head: number; at: number } | null>(null)
 
   useEffect(() => {
-    let stopped = false
-    let timer = 0
-    const poll = async () => {
-      try {
-        const next = await readHead()
-        const now = performance.now()
-        if (!stopped) {
-          const last = previous.current
-          if (last && next > last.head) setCadenceMs((now - last.at) / (next - last.head))
-          previous.current = { head: next, at: now }
-          setHead(next)
-        }
-      } catch {
-        // The page-level health state handles prolonged failures.
-      } finally {
-        if (!stopped) timer = window.setTimeout(poll, HEAD_POLL_MS)
-      }
-    }
-    void poll()
-    return () => {
-      stopped = true
-      window.clearTimeout(timer)
-    }
-  }, [])
+    if (!enabled) return
+    return subscribeToHeads(({ number }) => {
+      const now = performance.now()
+      const last = previous.current
+      if (last && number > last.head) setCadenceMs((now - last.at) / (number - last.head))
+      previous.current = { head: number, at: now }
+      setHead(number)
+    })
+  }, [enabled])
 
   return { head, cadenceMs }
 }

--- a/200ms-demo/src/styles.css
+++ b/200ms-demo/src/styles.css
@@ -215,8 +215,7 @@ footer { border-top: 1px solid var(--gray-15); display: grid; place-items: cente
   .rate-options { gap: 4px; }
   .rate-button, .stream-button { min-height: 36px; font-size: 9px; }
   .status-note { display: none; }
-  .ticker-head, .ticker-row { grid-template-columns: 1.2fr .8fr .8fr .55fr; }
-  .ticker-head span:last-child, .ticker-row span:last-child { display: none; }
+  .ticker-head, .ticker-row { grid-template-columns: 1.2fr .8fr .8fr .55fr .55fr; }
   .ticker-row { font-size: 8px; min-height: 25px; }
   footer { font-size: 7px; text-align: center; padding: 0 8px; }
 }

--- a/200ms-demo/src/ui/TxTicker.tsx
+++ b/200ms-demo/src/ui/TxTicker.tsx
@@ -40,7 +40,7 @@ export function TxTicker({ transactions }: Props) {
               <i aria-hidden="true" />{statusLabel[transaction.status]}
             </span>
             <span>{transaction.blockNumber ?? '—'}</span>
-            <span>{transaction.latencyMs ? `${transaction.latencyMs}ms` : '—'}</span>
+            <span>{transaction.latencyMs ? `${Math.round(transaction.latencyMs)}ms` : '—'}</span>
           </a>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- multiplex streamed transaction submission, chain reads, transfer logs, and block heads over Vibenet WSS
- replace normal-path receipt and head polling with WebSocket notifications; retain HTTP fallback and low-rate state reconciliation
- preserve the compact transfer table and original latency column

## Validation
- `npm run build`
- `npm run test:math`
- `git diff --check`
- manual 60/min public-Vibenet stream held for 65 seconds without a reset

Generated with Toshi